### PR TITLE
Attempt to fix `load_shared_lib()` when `package.cpath` contains `?.so`

### DIFF
--- a/lib/resty/signal.lua
+++ b/lib/resty/signal.lua
@@ -32,6 +32,10 @@ do
         local i = 1
 
         for k, _ in string_gmatch(cpath, "[^;]+") do
+            if k == "?.so" then
+                k = "./"
+            end
+
             local fpath = string_match(k, "(.*/)")
             fpath = fpath .. so_name
             -- Don't get me wrong, the only way to know if a file exist is


### PR DESCRIPTION
When one of the segments in `package.cpath` is '?.so', `string.match(k, "(.*/)")` returns `nil`, yielding an error:

```
$ resty \
    -e 'package.path = "./lib/?.lua"' \
    -e 'package.cpath = "?.so"' \
    -e 'require("resty.signal")'
ERROR: ./lib/resty/signal.lua:36: attempt to concatenate local 'fpath' (a nil value)
stack traceback:
        ./lib/resty/signal.lua:54: in main chunk
        [C]: in function 'require'
        (command line -e):1: in function 'inline_gen'
        init_worker_by_lua(nginx.conf:213):44: in function <init_worker_by_lua(nginx.conf:213):43>
        [C]: in function 'xpcall'
        init_worker_by_lua(nginx.conf:213):52: in function <init_worker_by_lua(nginx.conf:213):50>
```

Initially I tried to fix it with "smarter" string munging code:

```lua
local fpath = k:gsub("%?%.so", "")
               :gsub("/[^/]+$", "/")
```

This translates "?.so" to "", which yields a different error in the case where `./librestysignal.so` exists, because now `ffi.load()` does not treat the input as a path, but as a name to search within LD_LIBRARY_PATH:

```
$ resty \
    -e 'package.path = "./lib/?.lua"' \
    -e 'package.cpath = "?.so"' \
    -e 'require("resty.signal")'
ERROR: ./lib/resty/signal.lua:55: librestysignal.so: cannot open shared object file: No such file or directory
stack traceback:
        ./lib/resty/signal.lua:55: in main chunk
        [C]: in function 'require'
        (command line -e):1: in function 'inline_gen'
        init_worker_by_lua(nginx.conf:213):44: in function <init_worker_by_lua(nginx.conf:213):43>
        [C]: in function 'xpcall'
        init_worker_by_lua(nginx.conf:213):52: in function <init_worker_by_lua(nginx.conf:213):50>
```

...and unless LD_LIBRARY_PATH explicitly contains the CWD, it will fail:

```
$ resty -e 'assert(require("ffi").load("librestysignal.so"))'
ERROR: (command line -e):1: librestysignal.so: cannot open shared object file: No such file or directory
stack traceback:
        (command line -e):1: in function 'inline_gen'
        init_worker_by_lua(nginx.conf:213):44: in function <init_worker_by_lua(nginx.conf:213):43>
        [C]: in function 'xpcall'
        init_worker_by_lua(nginx.conf:213):52: in function <init_worker_by_lua(nginx.conf:213):50>
```
```
$ LD_LIBRARY_PATH="$PWD" resty -e 'assert(require("ffi").load("librestysignal.so"))'
```

After all of this trial and error, it seems that the easiest way to produce the desired result is just to special-case the handling of "?.so" by replacing it with "./", which effectively yields the following:

```
$ resty -e 'assert(require("ffi").load("./librestysignal.so"))'
```